### PR TITLE
Suggest order in gNOI cert ca_certificates

### DIFF
--- a/cert/cert.proto
+++ b/cert/cert.proto
@@ -282,6 +282,8 @@ message LoadCertificateRequest {
   // Groups of chained certificates should be last, where within, the root
   // certificate is the last one. E.g.:
   // CertA, CertB, CertB-Root, CertC, CertC-Intermediate, CertC-Root
+  // Note that on a forward looking iteration, CA Certificates will be managed
+  // by a dedicated gNOI service.
   repeated Certificate ca_certificates = 4;
 }
 

--- a/cert/cert.proto
+++ b/cert/cert.proto
@@ -278,6 +278,10 @@ message LoadCertificateRequest {
   // certificates should squash the existing bundle. This field provides a
   // simplified means to provision a CA bundle that can be used to validate
   // other peer's certificates.
+  // To improve performance in the Target, certificates can be ordered.
+  // Groups of chained certificates should be last, where within, the root
+  // certificate is the last one. E.g.:
+  // CertA, CertB, CertB-Root, CertC, CertC-Intermediate, CertC-Root
   repeated Certificate ca_certificates = 4;
 }
 


### PR DESCRIPTION
Set expectations in the order that CA certificates should have. This helps with improving performance in the Target when building chained relationships between certificates. This is merely suggested. Certificates can still be provided out of order.