### PR TITLE
Add required validation to new Certificates

### DIFF
--- a/docs/simplified_security_model.md
+++ b/docs/simplified_security_model.md
@@ -94,9 +94,9 @@ In order for the Target to validate the Client or a Peer's certificates, it must
 have a pool of one or more CA certificates. These are provisioned onto the
 Target by the Client during creation or rotation of the Target’s certificates.
 
-### Validate installed certificate (optional)
+### Validate installed certificate
 
-For increased security, the Target may use certificates in its CA pool to
+For increased security, the Target must use certificates in its CA pool to
 validate a newly installed certificate. This requires the CA pool to contain a
 CA certificate that can validate the new certificate.
 

--- a/docs/simplified_security_model.md
+++ b/docs/simplified_security_model.md
@@ -16,16 +16,16 @@ one that can be employed. Different security models can be defined to address
 specific scenarios.
 
 This simplified security model makes assumptions about the installation and
-rotation of Certificates & CA Certificates. Their assumed usage is applicable
+rotation of certificates & CA certificates. Their assumed usage is applicable
 not only to gNOI and gNMI, but also other services like OpenFlow.
 
 This simplified security model presumes that a secure connection between the
-Target and the Client already exist for installing and rotating Certificates.
+Target and the Client already exist for installing and rotating certificates.
 Bootstrapping is out of scope for this model.
 
 This simplified security model assumes low risk of man-in-the-middle attacks
 because it relinquishes mandating DNS verification for the Common Name of the
-respective Client and Target Certificates.
+respective Client and Target certificates.
 
 ## Client
 
@@ -38,7 +38,7 @@ A Target is defined as per the definition in the gNMI and gNOI specifications.
 ## Peer
 
 Peer is an entity that participates in establishing a connection with another
-entity, using whatever protocol that makes use of Certificates to secure that
+entity, using whatever protocol that makes use of certificates to secure that
 connection. An example would be an OpenFlow connection between an OpenFlow
 switch and an OpenFlow Controller. Target and Client are particular cases of a
 Peer.
@@ -61,7 +61,7 @@ authentication is described below.
 
 By authorized trust it is meant that the Target is granted the necessary
 credentials (by the Client) to be able to identify Peers as genuine (using
-whatever service uses these Certificates). The Target is authorized trust by the
+whatever service uses these certificates). The Target is authorized trust by the
 Client via the successful execution of either:
 
 *   gNOI certificate installation or rotation under a Secure connection (where
@@ -69,34 +69,40 @@ Client via the successful execution of either:
 *   other provisioning or bootstrapping mechanism described outside of the scope
     of this security model.
 
-## Target Certificate installation or rotation
+## Target certificate installation or rotation
 
 To initiate certificate installation using the gNOI Certificate Management
 service:
 
 1.  The Client sends parameters to the target so that it can generate a
-    Certificate Signing Request (CSR).
+    certificate Signing Request (CSR).
 2.  The Target then generates this CSR using its Private Key.
-3.  The Target then replies with the Certificate to the Client, which
-    subsequently provides the Certificate to the CA to be signed.
-4.  The signed Certificate is then returned to the Target by the Client and it
-    becomes one of the Target’s Certificates.
+3.  The Target then replies with the certificate to the Client, which
+    subsequently provides the certificate to the CA to be signed.
+4.  The signed certificate is then returned to the Target by the Client and it
+    becomes one of the Target’s certificates.
 
-Each one of the Target’s Certificate has a unique identifier, the Certificate
-ID. This ID is used both to install and to rotate a Certificate. Certificate
-installation for an existing Certificate ID MUST fail. Replacing an existing
-Certificate must rather use the Certificate rotation mechanism, whose steps are
+Each one of the Target’s certificate has a unique identifier, the certificate
+ID. This ID is used both to install and to rotate a certificate. certificate
+installation for an existing certificate ID MUST fail. Replacing an existing
+certificate must rather use the certificate rotation mechanism, whose steps are
 similar to the ones described above with the addition of final validation.
 
 ## Target CA pool
 
-In order for the Target to validate the Client or a Peer's Certificates, it must
-have a pool of one or more CA Certificates. These are provisioned onto the
-Target by the Client during creation or rotation of the Target’s Certificates.
+In order for the Target to validate the Client or a Peer's certificates, it must
+have a pool of one or more CA certificates. These are provisioned onto the
+Target by the Client during creation or rotation of the Target’s certificates.
+
+### Validate installed certificate (optional)
+
+For increased security, the Target may use certificates in its CA pool to
+validate a newly installed certificate. This requires the CA pool to contain a
+CA certificate that can validate the new certificate.
 
 ## Mutual Authentication
 
-Mutual authentication exists when two Peers validate each other's Certificate
+Mutual authentication exists when two Peers validate each other's certificate
 against their CA pools. Optionally, either the Client or the Target can validate
-that the Common Name (CN) in each other’s Certificates matches the resolved one
+that the Common Name (CN) in each other’s certificates matches the resolved one
 for the Peer address of the connection.


### PR DESCRIPTION
- make certificate lowercase
- add wording that allows to optionally validating a newly installed certificate against a CA present in the Target's CA pool.