### PR TITLE
IANA reserved port for gNOI/gNMI

### DIFF
--- a/docs/reserved_port.md
+++ b/docs/reserved_port.md
@@ -1,0 +1,8 @@
+# IANA Reserved port
+
+gNMI and gNOI services have the reserved port:
+
+`
+service: gnmi-gnoi
+port:         9339
+` 

--- a/docs/reserved_port.md
+++ b/docs/reserved_port.md
@@ -1,8 +1,8 @@
-# IANA Reserved port
+# IANA reserved port
 
-gNMI and gNOI services have the reserved port:
+gNMI and gNOI services have a reserved port.
 
 `
 service: gnmi-gnoi
 port:         9339
-` 
+`

--- a/docs/reserved_port.md
+++ b/docs/reserved_port.md
@@ -1,6 +1,7 @@
 # IANA reserved port
 
-gNMI and gNOI services have a reserved port.
+gNMI and gNOI services have a reserved port since May the 9th, 2019. Please use
+this port as the default & configured port in your systems.
 
 `
 service: gnmi-gnoi


### PR DESCRIPTION
Simple document advertising and suggesting the use of the recently reserved IANA port for gNOI & gNMI.