### PR TITLE
compile_protos.sh: explicit bash shebang

### DIFF
--- a/compile_protos.sh
+++ b/compile_protos.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -euo pipefail
 
 proto_imports=".:${GOPATH}/src/github.com/google/protobuf/src:${GOPATH}/src"


### PR DESCRIPTION
`/bin/sh` on my Debian Linux machine points to `/bin/dash` instead of `/bin/bash`, which breaks the `compile_protos.sh` script due to lack of support for `pipefail` in `dash`.

This sets the shebang to `bash`.