### PR TITLE
Updates to cert service to separate operations

### DIFF
--- a/cert/cert.proto
+++ b/cert/cert.proto
@@ -22,12 +22,16 @@ import "github.com/openconfig/gnoi/types/types.proto";
 
 package gnoi.certificate;
 
-option (types.gnoi_version) = "0.1.0";
+option (types.gnoi_version) = "0.2.0";
 
 // The Certificate Management Service exported by targets.
+//
 // The service primarily exports two main RPCs, Install & Rotate which are used
 // for installation of a new certificate, and rotation of an existing
 // certificate on a target, along with a few management related RPCs.
+//
+// In addition, the actions from the Install and Rotate RPCs are made available
+// as separate RPCs. These use the same request/response protos.
 service CertificateManagement {
 
   // Rotate will replace an existing Certificate on the target by creating a
@@ -131,6 +135,18 @@ service CertificateManagement {
   //
   rpc Install(stream InstallCertificateRequest)
       returns (stream InstallCertificateResponse);
+
+  // When credentials are generated on the device, generates a keypair and
+  // returns the Certificate Signing Request (CSR). The CSR has the public key,
+  // which when signed by the CA, becomes the Certificate.
+  rpc GenerateCSR(GenerateCSRRequest) returns (GenerateCSRResponse);
+
+  // Loads a certificate signed by a Certificate Authority (CA).
+  rpc LoadCertificate(LoadCertificateRequest) returns (LoadCertificateResponse);
+
+  // Loads a bundle of CA certificates.
+  rpc LoadCertificateAuthorityBundle(LoadCertificateAuthorityBundleRequest)
+      returns (LoadCertificateAuthorityBundleResponse);
 
   // An RPC to get the certificates on the target.
   rpc GetCertificates(GetCertificatesRequest) returns (GetCertificatesResponse);
@@ -282,8 +298,6 @@ message LoadCertificateRequest {
   // Groups of chained certificates should be last, where within, the root
   // certificate is the last one. E.g.:
   // CertA, CertB, CertB-Root, CertC, CertC-Intermediate, CertC-Root
-  // Note that on a forward looking iteration, CA Certificates will be managed
-  // by a dedicated gNOI service.
   repeated Certificate ca_certificates = 4;
 }
 
@@ -291,6 +305,22 @@ message LoadCertificateRequest {
 // If the target could not load the certificate, it must end the RPC stream with
 // a suitable RPC error about why the Certificate was not loaded.
 message LoadCertificateResponse {
+}
+
+// Bundle of CA certificates. Same as LoadCertificateRequest::ca_certificates.
+message LoadCertificateAuthorityBundleRequest {
+  // Squashes the existing certificate bundle.
+  // To improve performance in the Target, certificates can be ordered.
+  // Groups of chained certificates should be last, where within, the root
+  // certificate is the last one. E.g.:
+  // CertA, CertB, CertB-Root, CertC, CertC-Intermediate, CertC-Root
+  repeated Certificate ca_certificates = 1;
+}
+
+// Response from target after Loading a certificate authority bundle.
+// If the target could not load the certificates, it must end the RPC stream
+// with a suitable RPC error about why the Certificate was not loaded.
+message LoadCertificateAuthorityBundleResponse {
 }
 
 // A Finalize message is sent to the target to confirm the Rotation of


### PR DESCRIPTION
contributor:  jdwestbro

Adds RPCs to support separating operations within the Install and Rotate operations. New RPCs reuse current request/response protos.