### PR TITLE
Add intro document for authn/authz discussions.

### DIFF
--- a/auth/authn-authz-intro.md
+++ b/auth/authn-authz-intro.md
@@ -4,34 +4,81 @@
 **Published:** November 2020
 
 ## Problem Statement
-Historically, network devices have had a single store of configuration data, users with sufficient privilege levels are allowed to edit this data. Implementation-specific mechanisms have been used to restrict the subsets of configuration and telemetry that a particular user can interact with, such that it is possible to enforce particular roles interacting with a network device in specific manners. Often, the authorization policies that network operators have implemented have been coarse - for example, high privilege users being able to edit any configuration, or a single SNMP community having full access to all telemetry on the device. Typically, only lawful intercept credentials and configuration has been subject to a 'protected' configuration store, which was treated differently by the device.
+Historically, network devices have had a single store of configuration data,
+users with sufficient privilege levels are allowed to edit this data.
+Implementation-specific mechanisms have been used to restrict the subsets of
+configuration and telemetry that a particular user can interact with, such that
+it is possible to enforce particular roles interacting with a network device in
+specific manners. Often, the authorization policies that network operators have
+implemented have been coarse - for example, high privilege users being able to
+edit any configuration, or a single SNMP community having full access to all
+telemetry on the device. Typically, only lawful intercept credentials and
+configuration has been subject to a 'protected' configuration store, which was
+treated differently by the device.
 
-The OpenConfig project initially provided means to inter-work with existing means of authorization and authentication on network devices - providing means to supply a username and password via gRPC metadata for gNMI and gNOI - along with mutual TLS authentication. However, this approach has a number of limitations:
+The OpenConfig project initially provided means to inter-work with existing
+means of authorization and authentication on network devices - providing means
+to supply a username and password via gRPC metadata for gNMI and gNOI - along
+with mutual TLS authentication. However, this approach has a number of
+limitations:
 
-* It relies on an external run-time dependency to ensure that authentication/authorization is performed by the switch - particularly, the external AAA server being accessible. Thus introducing new failure modes that need to handled - such as fall-back credentials.
-* It introduces a potential vulnerability if the remote AAA is subject to MITM attacks.
-* In high-volume deployments (hundreds of thousands of switches), it introduces a new service that must be scaled.
-* It can introduce external factors which impact the performance of programmatic RPCs to the device - e.g., the latency between the switch and the AAA server.
-* It requires extension and definition of new patterns to be able to handle more granular authorization of access to the configuration and telemetry stored on a network device.
-* It requires a networking-specific approach to be taken for secure access to device endpoints rather than building on the wider industry open source developments, and their surrounding ecosystem.
+* It relies on an external run-time dependency to ensure that
+  authentication/authorization is performed by the switch - particularly, the
+  external AAA server being accessible. Thus introducing new failure modes that
+  need to handled - such as fall-back credentials.
+* It introduces a potential vulnerability if the remote AAA is subject to MITM
+  attacks.
+* In high-volume deployments (hundreds of thousands of switches), it introduces
+  a new service that must be scaled.
+* It can introduce external factors which impact the performance of
+  programmatic RPCs to the device - e.g., the latency between the switch and
+  the AAA server.
+* It requires extension and definition of new patterns to be able to handle
+  more granular authorization of access to the configuration and telemetry
+  stored on a network device.
+* It requires a networking-specific approach to be taken for secure access to
+  device endpoints rather than building on the wider industry open source
+  developments, and their surrounding ecosystem.
 
 ## Proposed Direction
 
-We propose to develop an approach which addresses a number of these concerns, particularly to provide:
+We propose to develop an approach which addresses a number of these concerns,
+particularly to provide:
 
-* A secure means by which authentication and authorization policy can be provided to a network device and stored locally.
-* Means by which this policy can interact with user identifiers that are specified as part of the gRPC connection - ideally building upon wider industry developments.
-* Means by which this policy can be used as a mechanism for authenticating users against other access mechanisms (e.g., local console, SSH) such that an operator can unify their authentication and authorization policy for network devices into a single definition.
-* Means within the policy to provide for granular access to a data tree which is described by a specified data model. This will particularly focus around the YANG tree that is defined by the OpenConfig data models.
+* A secure means by which authentication and authorization policy can be
+  provided to a network device and stored locally.
+ 
+* Means by which this policy can interact with user identifiers that are
+  specified as part of the gRPC connection - ideally building upon wider
+  industry developments.
 
-We envisage that this approach can coexist with authentication and authorization mechanisms that are already implemented by typical NOS today, whilst also evolving towards a unified, modernised approach.
+* Means by which this policy can be used as a mechanism for authenticating
+  users against other access mechanisms (e.g., local console, SSH) such that an
+  operator can unify their authentication and authorization policy for network
+  devices into a single definition.
+
+* Means within the policy to provide for granular access to a data tree which
+  is described by a specified data model. This will particularly focus around
+  the YANG tree that is defined by the OpenConfig data models.
+
+We envisage that this approach can coexist with authentication and
+authorization mechanisms that are already implemented by typical NOS today,
+whilst also evolving towards a unified, modernised approach.
 
 ### Next Steps
 
-We envisage that the work to define the security mechanism defined above involves a number of disparate steps:
+We envisage that the work to define the security mechanism defined above
+involves a number of disparate steps:
 
-1. Defining an approach for authentication, and the interface via which it is to be instantiated on a local network element.
-2. Defining an approach for authorization within specific services - both based on RPC called, as well as payload (particularly, path-based within gNMI).
-3. Defining means by which the services defined can coexist with existing mechanisms implemented in common NOSes, whilst ensuring the device remains secure.
+1. Defining an approach for authentication, and the interface via which it is
+   to be instantiated on a local network element.
+2. Defining an approach for authorization within specific services - both based
+   on RPC called, as well as payload (particularly, path-based within gNMI).
+3. Defining means by which the services defined can coexist with existing
+   mechanisms implemented in common NOSes, whilst ensuring the device remains
+   secure.
 
-We propose to use the [gNOI](https://github.com/openconfig/gnoi) repository as an initial starting point for this development work, and invite contributions from operator and vendor engineers within this branch and the corresponding pull requests.
+We propose to use the [gNOI](https://github.com/openconfig/gnoi) repository as
+an initial starting point for this development work, and invite contributions
+from operator and vendor engineers within this branch and the corresponding
+pull requests.

--- a/auth/authn-authz-intro.md
+++ b/auth/authn-authz-intro.md
@@ -1,0 +1,37 @@
+# Modernising Authentication and Authorization for Network Devices
+**Contributors:** danielwong<sup><small>†</small></sup>, johnwestbrook<sup><small>†</small></sup>, robjs<sup><small>†</small></sup>, morrowc<sup><small>†</small></sup>, aashaikh<sup><small>†</small></sup>  
+<sup><small>†</small></sup> @google.com  
+**Published:** November 2020
+
+## Problem Statement
+Historically, network devices have had a single store of configuration data, users with sufficient privilege levels are allowed to edit this data. Implementation-specific mechanisms have been used to restrict the subsets of configuration and telemetry that a particular user can interact with, such that it is possible to enforce particular roles interacting with a network device in specific manners. Often, the authorization policies that network operators have implemented have been coarse - for example, high privilege users being able to edit any configuration, or a single SNMP community having full access to all telemetry on the device. Typically, only lawful intercept credentials and configuration has been subject to a 'protected' configuration store, which was treated differently by the device.
+
+The OpenConfig project initially provided means to inter-work with existing means of authorization and authentication on network devices - providing means to supply a username and password via gRPC metadata for gNMI and gNOI - along with mutual TLS authentication. However, this approach has a number of limitations:
+
+* It relies on an external run-time dependency to ensure that authentication/authorization is performed by the switch - particularly, the external AAA server being accessible. Thus introducing new failure modes that need to handled - such as fall-back credentials.
+* It introduces a potential vulnerability if the remote AAA is subject to MITM attacks.
+* In high-volume deployments (hundreds of thousands of switches), it introduces a new service that must be scaled.
+* It can introduce external factors which impact the performance of programmatic RPCs to the device - e.g., the latency between the switch and the AAA server.
+* It requires extension and definition of new patterns to be able to handle more granular authorization of access to the configuration and telemetry stored on a network device.
+* It requires a networking-specific approach to be taken for secure access to device endpoints rather than building on the wider industry open source developments, and their surrounding ecosystem.
+
+## Proposed Direction
+
+We propose to develop an approach which addresses a number of these concerns, particularly to provide:
+
+* A secure means by which authentication and authorization policy can be provided to a network device and stored locally.
+* Means by which this policy can interact with user identifiers that are specified as part of the gRPC connection - ideally building upon wider industry developments.
+* Means by which this policy can be used as a mechanism for authenticating users against other access mechanisms (e.g., local console, SSH) such that an operator can unify their authentication and authorization policy for network devices into a single definition.
+* Means within the policy to provide for granular access to a data tree which is described by a specified data model. This will particularly focus around the YANG tree that is defined by the OpenConfig data models.
+
+We envisage that this approach can coexist with authentication and authorization mechanisms that are already implemented by typical NOS today, whilst also evolving towards a unified, modernised approach.
+
+### Next Steps
+
+We envisage that the work to define the security mechanism defined above involves a number of disparate steps:
+
+1. Defining an approach for authentication, and the interface via which it is to be instantiated on a local network element.
+2. Defining an approach for authorization within specific services - both based on RPC called, as well as payload (particularly, path-based within gNMI).
+3. Defining means by which the services defined can coexist with existing mechanisms implemented in common NOSes, whilst ensuring the device remains secure.
+
+We propose to use the [gNOI](https://github.com/openconfig/gnoi) repository as an initial starting point for this development work, and invite contributions from operator and vendor engineers within this branch and the corresponding pull requests.

--- a/auth/authn-authz-intro.md
+++ b/auth/authn-authz-intro.md
@@ -1,5 +1,9 @@
 # Modernising Authentication and Authorization for Network Devices
-**Contributors:** danielwong<sup><small>†</small></sup>, johnwestbrook<sup><small>†</small></sup>, robjs<sup><small>†</small></sup>, morrowc<sup><small>†</small></sup>, aashaikh<sup><small>†</small></sup>  
+
+**Contributors:** danielwong<sup><small>†</small></sup>,
+johnwestbrook<sup><small>†</small></sup>, robjs<sup><small>†</small></sup>,
+morrowc<sup><small>†</small></sup>, aashaikh<sup><small>†</small></sup>  
+
 <sup><small>†</small></sup> @google.com  
 **Published:** November 2020
 
@@ -47,16 +51,13 @@ particularly to provide:
 
 * A secure means by which authentication and authorization policy can be
   provided to a network device and stored locally.
- 
 * Means by which this policy can interact with user identifiers that are
   specified as part of the gRPC connection - ideally building upon wider
   industry developments.
-
 * Means by which this policy can be used as a mechanism for authenticating
   users against other access mechanisms (e.g., local console, SSH) such that an
   operator can unify their authentication and authorization policy for network
   devices into a single definition.
-
 * Means within the policy to provide for granular access to a data tree which
   is described by a specified data model. This will particularly focus around
   the YANG tree that is defined by the OpenConfig data models.
@@ -64,6 +65,13 @@ particularly to provide:
 We envisage that this approach can coexist with authentication and
 authorization mechanisms that are already implemented by typical NOS today,
 whilst also evolving towards a unified, modernised approach.
+
+In order that the new authentication and authorisation mechanisms clearly
+separate the security policy from the configuration of the device, we envisage
+that the policy that is supplied via this interface is the sole source of truth
+for authn/authz on the network device, and that the device cannot be changed to
+use alternative AAA means via other channels (e.g., gNMI-pushed configuration)
+when it is active.
 
 ### Next Steps
 


### PR DESCRIPTION
```
 * (A) auth/authn-authz-intro.md
  - Add a document that describes the problem statement and proposed
    development approach for authn and authz for devices that
    are managed according to OpenConfig APIs (e.g., gNOI, gNMI, gRIBI)
    - based on discussion with the contributors.
```

@danielywong @johnwestbrook @aashaikh - PTAL.