### PR TITLE
Add source_address field to common.RemoteDownload.

### DIFF
--- a/common/common.proto
+++ b/common/common.proto
@@ -41,4 +41,9 @@ message RemoteDownload {
   Protocol protocol = 2;
 
   types.Credentials credentials = 3;
+
+  // Optional source address used to initiate connections from the device.
+  // It can be either an IPv4 address or an IPv6 address, depending on the
+  // connection's destination address.
+  string source_address = 4;
 }


### PR DESCRIPTION
Allows for passing a source address argument to the underlying curl (or similar) command when it is necessary to specify a particular address/interface.