### PR TITLE
Clarify ping RPC expected behavior

### DIFF
--- a/system/system.proto
+++ b/system/system.proto
@@ -36,7 +36,8 @@ option (types.gnoi_version) = "1.0.0";
 service System {
   // Ping executes the ping command on the target and streams back
   // the results.  Some targets may not stream any results until all
-  // results are in.
+  // results are in.  The stream should provide single ping packet responses
+  // and must provide summary statistics.
   rpc Ping(PingRequest) returns (stream PingResponse) {}
 
   // Traceroute executes the traceroute command on the target and streams back


### PR DESCRIPTION
While looking into a test to verify ping behavior, I became unsure of what is expected in the PingResponse stream.  It looks like it would be valid to return individual packets OR summary statistics OR both the individual packets and the summary.

This change is to clarify that summary statistics are always expected, and individual packet metrics should be returned (ie, it's probably not reasonable for a flood request).