### PR TITLE
Update Reboot proto

### DIFF
--- a/system/system.proto
+++ b/system/system.proto
@@ -108,7 +108,8 @@ message RebootRequest {
   uint64 delay = 2;
   // Informational reason for the reboot.
   string message = 3;
-  // Optional sub-components to reboot.
+  // Optional, sub-components to reboot.
+  // If it's not set, reboot the whole network device.
   repeated types.Path subcomponents = 4;
   // Force reboot if sanity checks fail. (ex. uncommited configuration)
   bool force = 5;
@@ -138,7 +139,9 @@ enum RebootMethod {
 // request.
 message CancelRebootRequest {
   string message = 1;      // informational reason for the cancel
-  repeated types.Path subcomponents = 2; // optional sub-components.
+  // Optional, sub-components to cancel reboot.
+  // If it's not set, cancel all outstanding reboot requests.
+  repeated types.Path subcomponents = 2;
 }
 
 message CancelRebootResponse {
@@ -149,11 +152,21 @@ message RebootStatusRequest {
 }
 
 message RebootStatusResponse {
-  bool active = 1;      // If reboot is active.
-  uint64 wait = 2;      // Time left until reboot.
-  uint64 when = 3;      // Time to reboot in nanoseconds since the epoch.
-  string reason = 4;    // Reason for reboot.
-  uint32 count = 5;     // Number of reboots since active.
+  bool active = 1 [deprecated = true];  // If reboot is active.
+  uint64 wait = 2 [deprecated = true];  // Time left until reboot.
+  uint64 when = 3
+      [deprecated = true];  // Time to reboot in nanoseconds since the epoch.
+  string reason = 4 [deprecated = true];  // Reason for reboot.
+  uint32 count = 5 [deprecated = true];   // Number of reboots since active.
+
+  message Status {
+    bool active = 1;    // If reboot is active.
+    uint64 wait = 2;    // Time left until reboot.
+    uint64 when = 3;    // Time to reboot in nanoseconds since the epoch.
+    string reason = 4;  // Reason for reboot.
+    uint32 count = 5;   // Number of reboots since active.
+  }
+  repeated Status statuses = 6;
 }
 
 // A TimeRequest requests the current time accodring to the target.


### PR DESCRIPTION
Propose to:
* Clarify the behavior when the list of subcomponents is not set.
* Because `RebootStatusRequest` supports a list of subcomponents, the `RebootStatusResponse` should also have a way to identify status per subcomponent.

Another option is to deprecate the list of subcomponents in all reboot related proto, and only allow the request to target a single subcomponent. But then it raises more questions, like:
* Can the single subcomponent be an optional field?
* If it can be an optional field, what the default behavior if it's not set? 
* If the default behavior is to apply to the whole device (including all subcomponents), then any status reports should also be per component anyway. 
