### PR TITLE
installing the package in one command on all Supervisors.

### DIFF
--- a/os/os.proto
+++ b/os/os.proto
@@ -65,14 +65,23 @@ service OS {
   //                              <-- [Validated|InstallError]
   //
   // On a dual Supervisor Target, only the Active Supervisor runs this gNOI
-  // Service. The Install RPC applies to the Active Supervisor unless
+  // Service. 
+  // On systems which support installing the entire system with
+  // one upgrade command, one install RPC is sufficient to install the package 
+  // on all Supervisors. Such systems respond with cluster_validated set to true 
+  // in the Validated message. 
+  // On other systems, the Install RPC applies to the Active Supervisor unless
   // InstallRequest->TransferRequest->standby_supervisor is set, in which case
   // it applies to the Standby Supervisor. One Install RPC is required for each
   // Supervisor. The Supervisor order of package installation MUST not be fixed.
   //
-  // The Target MUST always attempt to copy the OS package between Supervisors
-  // first before accepting the transfer from the Client. The syncing progress
-  // is reported to the client with InstallResponse->SyncProgress messages.
+  // On systems which support installing the entire system with one upgrade
+  // command, package is available on all Supervisors or none. If the package
+  // is absent on the Active Supervisor, Target does not try to copy the package
+  // from the standby Supervisor.
+  // On other systems, the Target MUST always attempt to copy the OS package 
+  // between Supervisors first before accepting the transfer from the Client. The 
+  // syncing progress is reported to the client with InstallResponse->SyncProgress messages.
   //
   // If a switchover is triggered during the Install RPC, the RPC MUST
   // immediately abort with Error->type->UNEXPECTED_SWITCHOVER.
@@ -94,6 +103,8 @@ service OS {
   //                              ...
   //                              <-- [Validated|InstallError]
   //
+  //		- This scenario is not applicable to systems which install the package on all Supervisors
+  //		  with one command as one Install RPC updates the package on all Supervisors..
   //
   // Scenario 5 - When neither of the two Supervisors has the OS package:
   //
@@ -120,12 +131,18 @@ service OS {
   rpc Verify(VerifyRequest) returns (VerifyResponse);
 }
 
+// Systems which save image and config to secondary disk on the same Supervisor for
+// auto recovery from failed upgrade will snapshot to secondary disk if snapshot_to_secondary_disk
+// is true
 message InstallRequest {
   oneof request {
     TransferRequest transfer_request = 1;
     bytes transfer_content = 2;
     TransferEnd transfer_end = 3;
   }
+  // For auto-recovery, snapshot will save the image and config to secondary disk 
+  // on the same Supervisor.
+  bool snapshot_to_secondary_disk = 4;
 }
 
 message TransferRequest {
@@ -135,8 +152,8 @@ message TransferRequest {
   // the Target already has the OS package version it will reply with
   // InstallResponse->Validated. In the case that the target is a
   // single Supervisor device, or the partner Supervisor does not have the OS
-  // image specified, it will respond with InstallResponse->TransferReady. In
-  // this case, the client MUST subsequently transfer the image. In the case
+  // image specified, it will respond with InstallResponse->TransferReady. 
+  // In this case, the client MUST subsequently transfer the image. In the case
   // that the image is available on the peer Supervisor of a dual Supervisor
   // system, it will respond with InstallResponse->SyncProgress. In this,
   // latter, case - the client does not need to transfer the OS image. This
@@ -144,10 +161,17 @@ message TransferRequest {
   // transferred to the Target. The Target MUST never validate that this value
   // matches the one in the InstallResponse->Validated message, that is the
   // Client's responsibility.
+  // Systems which install the image on all Supervisors in one command
+  // will either have the image on both Supervisors or neither Supervisor.
+  // Such systems do not need to sync the image from peer Supervisor and
+  // will respond with TransferReady. 
   string version = 1;
 
   // For a Target with dual Supervisors setting this flag instructs the Target
   // to perform the action on the Standby Supervisor.
+  // Systems which install the package on all Supervisors will return an
+  // error code of NOT_SUPPORTED_ON_STANDBY if requested to install on standby
+  // only.
   bool standby_supervisor = 2;
 
   // Optionally specify the package size in bytes of the OS package being
@@ -177,6 +201,10 @@ message TransferEnd {
 // The InstallResponse is used by the Target to inform the Client about the
 // state of the Install RPC. At any stage of the process the Target can reply
 // with an Error message which MUST terminate the stream.
+// Systems which install the image on all Supervisors in one command
+// will either have the image on both Supervisors or neither Supervisor.
+// Such systems do not need to sync the image from peer Supervisor and
+// will respond with TransferReady if the package is absent on the Supervisor.
 message InstallResponse {
   oneof response {
     TransferReady transfer_ready = 1;
@@ -204,6 +232,8 @@ message TransferProgress {
 
 // The SyncProgress message signals the Client about the progress of
 // transferring the OS package between Supervisors.
+// Systems which install the package on all Supervisors do not need to
+// transfer the package between Supervisors and will not send SyncProgress.
 message SyncProgress {
   // The percentage that has transferred between Supervisors.
   uint32 percentage_transferred = 1;
@@ -219,6 +249,9 @@ message Validated {
   // used, and can contain information such as build date, target platform,
   // developer, etc.
   string description = 2;
+  // On systems which install the package on all Supervisors, cluster_validated
+  // is set to true
+  bool cluster_validated = 3;
 }
 
 // The InstallError message MUST be sent by the Target to the Client whenever an
@@ -253,7 +286,13 @@ message InstallError {
     UNEXPECTED_SWITCHOVER = 7;
     // Failed to sync the transferred OS package to the standby Supervisor. The
     // detail value MUST have more information.
+    // On systems which install the package on all Supervisors in one command,
+    // SYNC_FAIL will not be returned.
     SYNC_FAIL = 8;
+    // Systems which install the package on all Supervisors in one command
+    // will not support Install on backup Supervisor only and return this error
+    // when requested to install on standby Supervisor only.
+    NOT_SUPPORTED_ON_BACKUP = 9;
   }
   Type type = 1;
   string detail = 2;
@@ -261,6 +300,12 @@ message InstallError {
 
 // The ActivateRequest is sent by the Client to the Target to initiate a change
 // in the next bootable OS version that is to be used on the Target.
+// On systems which install the image on the entire system in one command,
+// the package is activated on all Supervisors upon one ActivateRequest. 
+// Upon activating the package on all Supervisors, ActivateResponse will
+// return cluster_activated as true.
+// Target will not support activating on standby Supervisor only and will return 
+// error NOT_SUPPORTED_ON_BACKUP.
 message ActivateRequest {
   // The version that is required to be activated and optionally immediattely
   // booted.
@@ -289,11 +334,18 @@ message ActivateResponse {
 // If the Target is already running the requested version in ActivateRequest,
 // then it replies with ActivateOK. If the Target has the OS package version
 // requested in ActivateRequest then it replies with ActivateOK and proceeds to
-// boot. In a Target with dual Supervisor, performing this RPC on the Active
-// Supervisor triggers a switchover before booting the (old)Active Supervisor.
-// The Target should always perform a switchover with the least impact possible
-// to forwarding.
+// boot. 
+// Systems which install the image on all Supervisors in one command will
+// activate the image on all Supervisors in response to one Activate RPC.
+// The entire system will be rebooted including both Supervisors. Such
+// systems will return cluster_activated set to true.
+//
+// On other systems, in a Target with dual Supervisor, performing this RPC on 
+// the Active Supervisor triggers a switchover before booting the (old)Active 
+// Supervisor. The Target should always perform a switchover with the least impact 
+// possible to forwarding.
 message ActivateOK {
+    bool cluster_activated = 1;
 }
 
 message ActivateError {
@@ -303,6 +355,9 @@ message ActivateError {
     // There is no OS package with the version requested for activation. This is
     // also used for an empty version string.
     NON_EXISTENT_VERSION = 1;
+    // Systems which activate on all Supervisors will return NOT_SUPPORTED_ON_BACKUP
+    // when asked to activate on standby Supervisor only.
+    NOT_SUPPORTED_ON_BACKUP = 2;
   }
   Type type = 1;
   string detail = 2;


### PR DESCRIPTION
Install RPC installs on both Supervisors and returns cluster_validated in Validated message as true on success. It returns NOT_SUPPORTED_ON_BACKUP in InstallError when asked to install on standby supervisor only. Image is present after Install on both Supervisors or neither Supervisor. Such systems do not need to sync the package from the peer Supervisor.

Activate RPC activates on both Supervisors and returns cluster_activated as true in ActivateOK message on success. It returns NOT_SUPPORTED_ON_BACKUP in ActivateError message when asked to activate on standby supervisors only. Such systems run the package by rebooting the entire system and do not need to switchover to the peer Supervisor before rebooting a Supervisor.

Added change to request snapshot of image and config to support auto recovery for systems which support snapshot to secondary disk on each Supervisor. When post upgrade reboot early init failures cause the system to boot from the second disk, the system auto recovers to the previously running image and config. This is specified by InstallRequest snapshot_to_secondary_disk.