### PR TITLE
[System] Clarify fields in the SwitchControlProcessorResponse

### DIFF
--- a/system/system.proto
+++ b/system/system.proto
@@ -96,8 +96,10 @@ message SwitchControlProcessorRequest {
 
 message SwitchControlProcessorResponse {
   types.Path control_processor = 1;
-  string version = 2; // Current software version.
-  int64 uptime = 3;   // Uptime in nanoseconds since epoch.
+  // Current software version of the target Control Processor.
+  string version = 2;
+  // Uptime of the target Control Processor in nanoseconds.
+  int64 uptime = 3;
 }
 
 // A RebootRequest requests the specified target be rebooted using the specified

--- a/system/system.proto
+++ b/system/system.proto
@@ -91,10 +91,12 @@ service System {
 }
 
 message SwitchControlProcessorRequest {
+  // Path to the target Control Processor.
   types.Path control_processor = 1;
 }
 
 message SwitchControlProcessorResponse {
+  // Path to the Control Processor that the system switched to.
   types.Path control_processor = 1;
   // Current software version of the target Control Processor.
   string version = 2;


### PR DESCRIPTION
This is to provide additional comments around the fields of the SwitchControlProcessorResponse.

The uptime comment has been changed to reflect the uptime nature of the field if that was the intention. For that reason, `since epoch` substring was removed, as epoch time indicates a point in time, not duration.

close #93 

PS1: I wonder if we need to clarify how to handle errors that might happen during the switchover? So far, rpc-sprcific errors are not part of the spec. 

PTAL @marcushines 