### PR TITLE
Adding gnoi test operations files

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 go_library(
     name = "test",
@@ -18,4 +20,46 @@ go_test(
         "//types:types_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
+)
+
+# BlackBoxTest.
+proto_library(
+    name = "blackbox_test_proto",
+    srcs = ["blackbox_test.proto"],
+    deps = ["//types:types_proto",
+            "@go_googleapis//google/rpc:status_proto",
+           ],
+)
+
+go_proto_library(
+    name = "blackbox_test_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    proto = ":blackbox_test_proto",
+    importpath = "github.com/openconfig/gnoi/test",
+    deps = ["//types:types_go_proto",
+     "@go_googleapis//google/rpc:status_go_proto"],
+)
+
+cc_proto_library(
+    name = "blackbox_test_cc_proto",
+    deps = [":blackbox_test_proto"],
+)
+
+# WhiteBoxTest.
+proto_library(
+    name = "whitebox_test_proto",
+    srcs = ["whitebox_test.proto"],
+)
+
+go_proto_library(
+    name = "whitebox_test_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    proto = ":whitebox_test_proto",
+    importpath = "github.com/openconfig/gnoi/test",
+    deps = ["//types:types_go_proto"],
+)
+
+cc_proto_library(
+    name = "whitebox_test_cc_proto",
+    deps = [":whitebox_test_proto"],
 )

--- a/test/blackbox_test.proto
+++ b/test/blackbox_test.proto
@@ -1,0 +1,127 @@
+// BlackBoxTest represents a list of test APIs that facilitates testing the
+// switch/network (injecting events, mutating switch state etc.)
+
+syntax = "proto3";
+
+package gnoi.test;
+
+//import "enums/enums.proto";
+import "types/types.proto";
+import "google/rpc/status.proto";
+
+service BlackBoxTest {
+  // This RPC allows the state of a transceiver (for both optical, and copper
+  // cable) to be set on the switch. The goal is to simulate the
+  // insertion/removal of a transceiver and verify that the switch initializes
+  // the transceiver correctly. This RPC maps to the `fake` removal of a
+  // physical module, and un-doing the `fake` removal (i.e., insert). This does
+  // not implement any fake insertion of a non-present module. The switch
+  // remembers the state of a transceiver based on this RPC (until reboot).
+  rpc SetTransceiverState(SetTransceiverStateRequest)
+      returns (SetTransceiverStateResponse) {}
+
+  // This RPC changes the state of the link connected to the specified port(s).
+  // The goal is to simulate a link going up/down due to factors external to the
+  // switch: copper cable/fiber removed, cable/fiber gone bad, etc.
+  rpc SetHardwareLinkState(SetHardwareLinkStateRequest)
+      returns (SetHardwareLinkStateResponse) {}
+
+  // This RPC sets the Alarm state in the switch. The caller is able to set the
+  // id, resource, description, alarm severity, and type. One goal is to put the
+  // switch into a critical state to verify that the switch prevents write
+  // operations to the switch over P4RT/gNMI/gNOI and that the switch continues
+  // to forward packets and export telemetry.
+  rpc SetAlarm(SetAlarmRequest) returns (SetAlarmResponse) {}
+
+  // Switch performs an internal consistency check. It verifies if the hardware
+  // contents match with the corresponding software contents. If no component is
+  // specified, verification runs for all valid components. It performs
+  // verification on the supplied components otherwise. RPC fails for any
+  // invalid component.
+  rpc VerifyState(VerifyStateRequest) returns (VerifyStateResponse);
+}
+
+message SetTransceiverStateRequest {
+  message TransceiverStateRequest {
+    enum TransceiverState {
+      STATE_UNSPECIFIED = 0;
+      REMOVE = 1;       // Remove a module.
+      UNDO_REMOVE = 2;  // Undo removal (i.e., insertion) of a module.
+    }
+
+    // Path to the transceiver component.
+    .gnoi.types.Path transceiver = 1;
+    TransceiverState state = 2;
+  }
+
+  repeated TransceiverStateRequest transceiver_requests = 1;
+}
+
+message SetTransceiverStateResponse {
+  message TransceiverStateResponse {
+    // Path to the transceiver component.
+    .gnoi.types.Path transceiver = 1;
+    // Status of the operation. In case of failures, canonical error code and
+    // message show the details.
+    google.rpc.Status status = 2;
+  }
+
+  repeated TransceiverStateResponse transceiver_responses = 1;
+}
+
+message SetHardwareLinkStateRequest {
+  message HardwareLinkStateInfo {
+    // Path to the interface.
+    .gnoi.types.Path interface = 1;
+    bool enabled = 2;
+  }
+
+  repeated HardwareLinkStateInfo link_requests = 1;
+}
+
+message SetHardwareLinkStateResponse {
+  message SetHardwareLinkStateStatus {
+    // Path to the interface.
+    .gnoi.types.Path interface = 1;
+    // Status of the operation. In case of failures, canonical error code and
+    // message show the details.
+    google.rpc.Status status = 2;
+  }
+
+  repeated SetHardwareLinkStateStatus link_responses = 1;
+}
+
+message SetAlarmRequest {
+  // ID associated with the alarm.
+  string id = 1;
+  // Resource that raises the alarm. Must be a valid component ID.
+  string resource = 2;
+  // Description of the alarm.
+  string description = 3;
+  // OPENCONFIG_ALARM_SEVERITY from the OpenConfig system model.
+  // openconfig.enums.OpenconfigAlarmTypesOPENCONFIGALARMSEVERITY severity = 4;
+  // OPENCONFIG_ALARM_TYPE_ID from the OpenConfig system model.
+  // openconfig.enums.OpenconfigAlarmTypesOPENCONFIGALARMTYPEID type = 5;
+}
+
+message SetAlarmResponse {}
+
+message VerifyStateRequest {
+  // Resources that verify states. Must be valid component IDs.
+  repeated string components = 1;
+}
+
+message VerifyStateResponse {
+  message VerifyStateResult {
+    string component = 1;
+    // Status of the operation. In case of failures, canonical error code
+    // and message show the details.
+    google.rpc.Status status = 2;
+  }
+
+  // Overall (aggregated) test result. Overall result succeeds if and only
+  // if the test passes for all components. If it fails for any component,
+  // the overall result is a failure.
+  bool success = 1;
+  repeated VerifyStateResult results = 2;
+}

--- a/test/whitebox_test.proto
+++ b/test/whitebox_test.proto
@@ -1,0 +1,39 @@
+// WhiteBoxTest represents a list of test APIs that facilitates testing the
+// switch/controller (injecting events, mutating switch state etc.)
+
+syntax = "proto3";
+
+package gnoi.gnoi;
+
+service WhiteBoxTest {
+  // This RPC blocks or permits GNMI and P4RT connections from controller either
+  // on in band or out of band or on both channels.
+  // The goal is to simulate controller connection loss in various tests.
+  rpc SetControllerConnectionState(SetControllerConnectionStateRequest)
+      returns (SetControllerConnectionStateResponse) {}
+}
+
+message SetControllerConnectionStateRequest {
+  enum State {
+    UNKNOWN_STATE = 0;
+    BLOCK = 1;         // Block connections to switch.
+    REMOVE_BLOCK = 2;  // Permit connections to switch.
+  }
+
+  enum ConnectionType {
+    UNKNOWN_TYPE = 0;
+    ALL_CONNECTIONS = 1;  // Both in band and out of band connecions.
+    IN_BAND = 2;          // only in band connections.
+    OUT_OF_BAND = 3;      // only out of band connections.
+  }
+
+  State state = 1;
+  ConnectionType type = 2;
+  // Controller ipv4 addresses in prefix format ex: 10.1.1.1/32.
+  repeated string ipv4_prefix = 3;
+
+  // Controller ipv6 addresses in prefix format ex: 1000::1/128.
+  repeated string ipv6_prefix = 4;
+}
+
+message SetControllerConnectionStateResponse {}


### PR DESCRIPTION
BlackBoxTest represents a list of test APIs that facilitates testing the switch/network (injecting events, mutating switch state etc.). WhiteBoxTest represents a list of test APIs that facilitates testing the switch and controller connections.