### PR TITLE
change "types" target for healthz

### DIFF
--- a/healthz/BUILD.bazel
+++ b/healthz/BUILD.bazel
@@ -40,7 +40,7 @@ go_proto_library(
     importpath = "github.com/openconfig/gnoi/healthz",
     protos = [":healthz_proto"],
     deps = [
-        "//types:types_go_proto",
+        "//types",
     ],
 )
 


### PR DESCRIPTION
The mixed targets between different go_proto_library in each proto was making it difficult to avoid linker problems.

I ran into this when updating to the newest version of gnoi. Was able to work around by including this patch internally.

```
+ gbazelisk run --config=remote --collect_code_coverage //gnmi_server:gnmi_server_test_image
DEBUG: /usr/local/google/home/mostlyharmless/.cache/bazel/_bazel_mostlyharmless/355348234978af7cf0929b321268140c/external/io_bazel_rules_go/go/private/actions/link.bzl:59:18: Multiple copies of github.com/openconfig/gnoi/types passed to the linker. Ignoring bazel-out/k8-fastbuild-ST-4a519fd6d3e4/bin/external/com_github_openconfig_gnoi/types/types_go_proto.a in favor of bazel-out/k8-fastbuild-ST-4a519fd6d3e4/bin/external/com_github_openconfig_gnoi/types/types.a
INFO: Analyzed target //gnmi_server:gnmi_server_test_image (2 packages loaded, 11 targets configured).
INFO: Found 1 target...
INFO: Docker sandboxing is supported
ERROR: /usr/local/google/home/mostlyharmless/gnmi/sonic-gnmi/gnmi_server/BUILD.bazel:107:8: GoLink gnmi_server/gnmi_server_test_/gnmi_server_test failed: (Exit 1): builder failed: error executing command (from target //gnmi_server:gnmi_server_test) bazel-out/k8-opt-exec-2B5CBBC6-ST-625e526ca8a8/bin/external/go_sdk/builder_reset/builder '-param=bazel-out/k8-fastbuild-ST-4a519fd6d3e4/bin/gnmi_server/gnmi_server_test_/gnmi_server_test-0.params' -- ... (remaining 11 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
link: package conflict error: github.com/openconfig/gnoi/healthz: package imports github.com/openconfig/gnoi/types
          was compiled with: @com_github_openconfig_gnoi//types:types_go_proto
        but was linked with: @com_github_openconfig_gnoi//types:types
See https://github.com/bazelbuild/rules_go/issues/1877.
Target //gnmi_server:gnmi_server_test_image failed to build
```