### PR TITLE
Update README.md to indicate expected ArtifactResponses

### DIFF
--- a/healthz/README.md
+++ b/healthz/README.md
@@ -174,7 +174,11 @@ is implemented as a server-side streaming RPC. The `Artifact` RPC ensures that
 a target sends these potentially large artifacts only when explicitly requested
 by the client.
 
-###test
+Each artifact that is returned in the `Artifact` RPC call should contain
+ArtifactResponses in the following order:
+- ArtifactHeader
+- one or more bytes/proto
+- ArtifactTrailer
 
 #### Healthz.Check()
 

--- a/healthz/README.md
+++ b/healthz/README.md
@@ -174,6 +174,8 @@ is implemented as a server-side streaming RPC. The `Artifact` RPC ensures that
 a target sends these potentially large artifacts only when explicitly requested
 by the client.
 
+###test
+
 #### Healthz.Check()
 
 ```protobuf


### PR DESCRIPTION
The current /gnoi/healthz/README.md is not explicit to vendors on what ArtifactResponses order is expected for each artifact. This update explicitly defines the ArtifactResponse order expected for each artifact.