### PR TITLE
Add config to skip DHCP boot to gnoi.FactoryReset.

### DIFF
--- a/factory_reset/factory_reset.proto
+++ b/factory_reset/factory_reset.proto
@@ -22,6 +22,9 @@ service FactoryReset {
   // Optionally allows for the Target to zero-fill permanent storage where state
   // data is stored.
   //
+  // Optionally allows for the Target to skip DHCP boot and populate with the
+  // provided management configuration.
+  //
   // If any of the optional flags is set but not supported, a gRPC Status with
   // code INVALID_ARGUMENT must be returned with the details value set to a
   // properly populated ResetError message.
@@ -34,8 +37,20 @@ message StartRequest {
   bool factory_os = 1;
   // Instructs the Target to zero fill persistent storage state data.
   bool zero_fill = 2;
-  // Instructs the Target to retain certificates
+  // Instructs the Target to retain certificates.
   bool retain_certs = 3;
+  // Instructs the Target to populate with the provided Ip/Routing information
+  // and skip DHCP boot.
+  ManagementConfig mgmt_config = 4;
+}
+
+message ManagementConfig {
+  repeated string bootz_uris = 1;
+  string device_ip = 2;
+  string mask_length = 3;
+  string gateway_ip = 4;
+  repeated string management_routes = 5;
+  repeated string dns_servers = 6;
 }
 
 message ResetSuccess {
@@ -47,6 +62,8 @@ message ResetError {
   bool factory_os_unsupported = 1;
   // Zero fill is not supported.
   bool zero_fill_unsupported = 2;
+  // Management config is not supported.
+  bool mgmt_config_unsupported = 5;
   // Unspecified error, must provide detail message.
   bool other = 3;
   string detail = 4;


### PR DESCRIPTION
For Bootz testing we want an interface to skip DHCP boot to be able to write smaller integration tests. One test should DHCP boot up to the point of reaching out to the Bootz server. Another test should skip DHCP boot and test the remaining bootz protocol to get a functioning device.