### PR TITLE
Update gNOI.bgp.proto with HARD_RESET and GRACEFUL_RESET

### DIFF
--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -39,12 +39,14 @@ message ClearBGPNeighborRequest {
   enum Mode {
     SOFT = 0;         // Send route-refresh and reapply policy.
     SOFTIN = 1;       // Re-apply inbound policy on stored Adj-RIB-In.
-    HARD = 2;         // Teardown, restart TCP connection, Send Cease 
+    HARD = 2;         // Teardown and restart TCP connection.
+    HARD_RESET = 3;         // Teardown, restart TCP connection, Send Cease 
     // notification (code 6) with subcode 4. However, if the "N" bit for 
     // Graceful-Restart" is set, then encapsulate the original Notification
     // message in the data portion of the Subcode 9 message as per 
     // rfc8538#section-3.1 and also Flush the routes.
-    GRACEFUL = 4;     // Teardown, restart TCP connection, Send Cease notification (code 6) with subcode 4.
+    GRACEFUL_RESET = 4;     // Teardown, restart TCP connection, Send Cease 
+    // notification (code 6) with subcode 4.
   }
   Mode mode = 3;       // Which mode to use for the clear operation.
 }

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -40,7 +40,7 @@ message ClearBGPNeighborRequest {
     SOFT = 0;         // Send route-refresh and reapply policy.
     SOFTIN = 1;       // Re-apply inbound policy on stored Adj-RIB-In.
     HARD = 2;         // Teardown, restart TCP connection, Send Cease notification (code 6) with subcode 9 and flush all routes.
-    GRACEFUL = 4;     // Teardown, restart TCP connection, Send Cease notification (code 6) with subcode 4 and dont flush routes.
+    GRACEFUL = 4;     // Teardown, restart TCP connection, Send Cease notification (code 6) with subcode 4.
   }
   Mode mode = 3;       // Which mode to use for the clear operation.
 }

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -40,13 +40,15 @@ message ClearBGPNeighborRequest {
     SOFT = 0;         // Send route-refresh and reapply policy.
     SOFTIN = 1;       // Re-apply inbound policy on stored Adj-RIB-In.
     HARD = 2;         // Teardown and restart TCP connection.
-    HARD_RESET = 3;         // Teardown, restart TCP connection, Send Cease 
-    // notification (code 6) with subcode 4. However, if the "N" bit for 
-    // Graceful-Restart" is set, then encapsulate the original Notification
-    // message in the data portion of the Subcode 9 message as per 
-    // rfc8538#section-3.1 and also Flush the routes.
-    GRACEFUL_RESET = 4;     // Teardown, restart TCP connection, Send Cease 
-    // notification (code 6) with subcode 4.
+    // If the "N" bit for Graceful-Restart" is set, then encapsulate the original 
+    // Notification message in the data portion of the Subcode 9 message per 
+    // rfc8538#section-3.1 and Flush routes associated with this neighbor.
+    // Otherwise, send BGP Cease notification (code 6) with subcode 4 then 
+    // teardown and restart the TCP connection.
+    HARD_RESET = 3;
+    // Send BGP Cease notification (code 6) with subcode 4 then 
+    // teardown and restart the TCP connection.
+    GRACEFUL_RESET = 4;     
   }
   Mode mode = 3;       // Which mode to use for the clear operation.
 }

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -31,6 +31,11 @@ service BGP {
 
 }
 
+// ClearBGPNeighbor clears a BGP session. On success, this RPC returns an 
+// empty ClearBGPNeighborResponse. In case of a failure to meet a 
+// precondition (e.g., requesting a graceful reset on a session where 
+// Graceful Restart is not enabled), the server MUST return a gRPC error 
+// with the relevant status code.
 message ClearBGPNeighborRequest {
   string address = 1;  // IPv4 or IPv6 BGP neighbor address to clear.
   // Routing instance containing the neighbor. Defaults to the global routing
@@ -70,8 +75,8 @@ message ClearBGPNeighborRequest {
     // control plane restarts. The following actions are required for each scenario:
     
     // - If the BGP session does not support Graceful Restart (GR):
-    //  - The implementation must return an error, as a graceful reset cannot be
-    //   performed.
+    //  - The implementation MUST return a gRPC error with the status code
+    //    `FAILED_PRECONDITION`, as a graceful reset cannot be performed.
     
     // - If the BGP session supports GR but does not support RFC 8538:
     //   - The implementation must not send a BGP NOTIFICATION message.

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -40,14 +40,54 @@ message ClearBGPNeighborRequest {
     SOFT = 0;         // Send route-refresh and reapply policy.
     SOFTIN = 1;       // Re-apply inbound policy on stored Adj-RIB-In.
     HARD = 2;         // Teardown and restart TCP connection.
-    // If the "N" bit for Graceful-Restart" is set, then encapsulate the original 
-    // Notification message in the data portion of the Subcode 9 message per 
-    // rfc8538#section-3.1 and Flush routes associated with this neighbor.
-    // Otherwise, send BGP Cease notification (code 6) with subcode 4 then 
-    // teardown and restart the TCP connection.
+    // When handling a request to perform a HARD_reset on a BGP session, the
+    // implementation's behavior is determined by the capabilities negotiated with
+    // the peer. The following actions are required for each scenario:
+    
+    // - If the BGP session does not support Graceful Restart (GR):
+    //     - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
+    //       peer. The value of any subcode sent is considered irrelevant.
+    //     - It must reset the TCP session.
+    //     - It must flush all routes learned over this session.
+    
+    // - If the BGP session supports GR but does not support RFC 8538:
+    //     - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
+    //       peer. The value of any subcode sent is considered irrelevant.
+    //     - It must reset the TCP session.
+    //     - It must flush all routes learned over this session.
+    
+    // - If the BGP session supports both GR and RFC 8538:
+    //     - The implementation must send a BGP Cease NOTIFICATION (code 6) with the
+    //       specific subcode for "Hard Reset" (value 9).
+    //     - It must reset the TCP session.
+    //     - It must flush all routes learned over this session.
+
     HARD_RESET = 3;
-    // Send BGP Cease notification (code 6) with subcode 4 then 
-    // teardown and restart the TCP connection.
+    // When handling a request to perform a GRACEFUL_RESET on a BGP session, the
+    // implementation's behavior is determined by the capabilities negotiated with
+    // the peer. A GRACEFUL_RESET is intended to trigger a graceful session
+    // teardown, allowing the forwarding plane to be preserved while the BGP
+    // control plane restarts. The following actions are required for each scenario:
+    
+    // - If the BGP session does not support Graceful Restart (GR):
+    //   - The implementation must return an error, as a graceful reset cannot be
+    //   performed.
+    
+    // - If the BGP session supports GR but does not support RFC 8538:
+    //   - The implementation must not send a BGP NOTIFICATION message.
+    //   - It must reset the TCP session.
+    //   - It must retain all routes learned over this session for a period derived
+    //   from the relevant timers (e.g., restart-time, LLGR, and/or ExRR), depending
+    //   on the device configuration and negotiated capabilities.
+    
+    // - If the BGP session supports both GR and RFC 8538:
+    //   - The implementation must send a BGP Cease NOTIFICATION (code 6) with the
+    //   subcode "Other Configuration Change" (value 6).
+    //   - It must reset the TCP session.
+    //   - It must retain all routes learned over this session for a period derived
+    //   from the relevant timers (e.g., restart-time, LLGR, and/or ExRR), depending
+    //   on the device configuration and negotiated capabilities.
+
     GRACEFUL_RESET = 4;     
   }
   Mode mode = 3;       // Which mode to use for the clear operation.

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -48,7 +48,7 @@ message ClearBGPNeighborRequest {
     // TCP connection. This field does not define what the behavior is regarding
     // BGP graceful restart. The HARD_RESET and GRACEFUL_RESET fields
     // should be used instead of HARD.
-    HARD = 2;      [deprecated=true];
+    HARD = 2 [deprecated=true];
     // When handling a request to perform a HARD_RESET on a BGP session, the
     // implementation's behavior is determined by the capabilities negotiated
     // with the peer. The following actions are required for each scenario:

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -45,22 +45,22 @@ message ClearBGPNeighborRequest {
     // the peer. The following actions are required for each scenario:
     
     // - If the BGP session does not support Graceful Restart (GR):
-    //     - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
-    //       peer. The value of any subcode sent is considered irrelevant.
-    //     - It must reset the TCP session.
-    //     - It must flush all routes learned over this session.
+    //  - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
+    //    peer. The value of any subcode sent is considered irrelevant.
+    //  - It must reset the TCP session.
+    //  - It must flush all routes learned over this session.
     
     // - If the BGP session supports GR but does not support RFC 8538:
-    //     - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
+    //  - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
     //       peer. The value of any subcode sent is considered irrelevant.
-    //     - It must reset the TCP session.
-    //     - It must flush all routes learned over this session.
+    //  - It must reset the TCP session.
+    //  - It must flush all routes learned over this session.
     
     // - If the BGP session supports both GR and RFC 8538:
-    //     - The implementation must send a BGP Cease NOTIFICATION (code 6) with the
-    //       specific subcode for "Hard Reset" (value 9).
-    //     - It must reset the TCP session.
-    //     - It must flush all routes learned over this session.
+    //  - The implementation must send a BGP Cease NOTIFICATION (code 6) with the
+    //    specific subcode for "Hard Reset" (value 9).
+    //  - It must reset the TCP session.
+    //  - It must flush all routes learned over this session.
 
     HARD_RESET = 3;
     // When handling a request to perform a GRACEFUL_RESET on a BGP session, the
@@ -70,7 +70,7 @@ message ClearBGPNeighborRequest {
     // control plane restarts. The following actions are required for each scenario:
     
     // - If the BGP session does not support Graceful Restart (GR):
-    //   - The implementation must return an error, as a graceful reset cannot be
+    //  - The implementation must return an error, as a graceful reset cannot be
     //   performed.
     
     // - If the BGP session supports GR but does not support RFC 8538:

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -49,7 +49,7 @@ message ClearBGPNeighborRequest {
     // BGP graceful restart. The HARD_RESET and GRACEFUL_RESET fields 
     // should be used instead of HARD.
     HARD = 2;      [deprecated=true];
-    // When handling a request to perform a HARD_reset on a BGP session, the
+    // When handling a request to perform a HARD_RESET on a BGP session, the
     // implementation's behavior is determined by the capabilities negotiated with
     // the peer. The following actions are required for each scenario:
     

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -31,10 +31,10 @@ service BGP {
 
 }
 
-// ClearBGPNeighbor clears a BGP session. On success, this RPC returns an 
-// empty ClearBGPNeighborResponse. In case of a failure to meet a 
-// precondition (e.g., requesting a graceful reset on a session where 
-// Graceful Restart is not enabled), the server MUST return a gRPC error 
+// ClearBGPNeighbor clears a BGP session. On success, this RPC returns an
+// empty ClearBGPNeighborResponse. In case of a failure to meet a
+// precondition (e.g., requesting a graceful reset on a session where
+// Graceful Restart is not enabled), the server MUST return a gRPC error
 // with the relevant status code.
 message ClearBGPNeighborRequest {
   string address = 1;  // IPv4 or IPv6 BGP neighbor address to clear.
@@ -46,12 +46,12 @@ message ClearBGPNeighborRequest {
     SOFTIN = 1;       // Re-apply inbound policy on stored Adj-RIB-In.
     // The HARD Mode is intended to teardown and restart the BGP session
     // TCP connection. This field does not define what the behavior is regarding
-    // BGP graceful restart. The HARD_RESET and GRACEFUL_RESET fields 
+    // BGP graceful restart. The HARD_RESET and GRACEFUL_RESET fields
     // should be used instead of HARD.
     HARD = 2;      [deprecated=true];
     // When handling a request to perform a HARD_RESET on a BGP session, the
-    // implementation's behavior is determined by the capabilities negotiated with
-    // the peer. The following actions are required for each scenario:
+    // implementation's behavior is determined by the capabilities negotiated
+    // with the peer. The following actions are required for each scenario:
     // - If the BGP session does not support Graceful Restart (GR):
     //   - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
     //    peer. The value of any subcode sent is considered irrelevant.
@@ -63,33 +63,36 @@ message ClearBGPNeighborRequest {
     //   - It must reset the TCP session.
     //   - It must flush all routes learned over this session.
     // - If the BGP session supports both GR and RFC 8538:
-    //   - The implementation must send a BGP Cease NOTIFICATION (code 6) with the
-    //    specific subcode for "Hard Reset" (value 9).
+    //   - The implementation must send a BGP Cease NOTIFICATION (code 6) with
+    //    the specific subcode for "Hard Reset" (value 9).
     //   - It must reset the TCP session.
     //   - It must flush all routes learned over this session.
     HARD_RESET = 3;
     // When handling a request to perform a GRACEFUL_RESET on a BGP session, the
-    // implementation's behavior is determined by the capabilities negotiated with
-    // the peer. A GRACEFUL_RESET is intended to trigger a graceful session
+    // implementation's behavior is determined by the capabilities negotiated
+    // with the peer. A GRACEFUL_RESET is intended to trigger a graceful session
     // teardown, allowing the forwarding plane to be preserved while the BGP
-    // control plane restarts. The following actions are required for each scenario:
+    // control plane restarts. The following actions are required for each
+    // scenario:
     // - If the BGP session does not support Graceful Restart (GR):
     //   - The implementation MUST return a gRPC error with the status code
     //    `FAILED_PRECONDITION`, as a graceful reset cannot be performed.
     // - If the BGP session supports GR but does not support RFC 8538:
     //   - The implementation must not send a BGP NOTIFICATION message.
     //   - It must reset the TCP session.
-    //   - It must retain all routes learned over this session for a period derived
-    //   from the relevant timers (e.g., restart-time, LLGR, and/or ExRR), depending
-    //   on the device configuration and negotiated capabilities.
+    //   - It must retain all routes learned over this session for a period
+    //    derived from the relevant timers (e.g., restart-time, LLGR, and/or
+    //    ExRR), depending on the device configuration and negotiated
+    //    capabilities.
     // - If the BGP session supports both GR and RFC 8538:
-    //   - The implementation must send a BGP Cease NOTIFICATION (code 6) with the
-    //   subcode "Other Configuration Change" (value 6).
+    //   - The implementation must send a BGP Cease NOTIFICATION (code 6) with
+    //   the subcode "Other Configuration Change" (value 6).
     //   - It must reset the TCP session.
-    //   - It must retain all routes learned over this session for a period derived
-    //   from the relevant timers (e.g., restart-time, LLGR, and/or ExRR), depending
-    //   on the device configuration and negotiated capabilities.
-    GRACEFUL_RESET = 4;     
+    //   - It must retain all routes learned over this session for a period
+    //   derived from the relevant timers (e.g., restart-time, LLGR, and/or
+    //   ExRR), depending on the device configuration and negotiated
+    //   capabilities.
+    GRACEFUL_RESET = 4;
   }
   Mode mode = 3;       // Which mode to use for the clear operation.
 }

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -44,7 +44,11 @@ message ClearBGPNeighborRequest {
   enum Mode {
     SOFT = 0;         // Send route-refresh and reapply policy.
     SOFTIN = 1;       // Re-apply inbound policy on stored Adj-RIB-In.
-    HARD = 2;         // Teardown and restart TCP connection.
+    // The HARD Mode is intended to teardown and restart the BGP session
+    // TCP connection. This field does not define what the behavior is regarding
+    // BGP graceful restart. The HARD_RESET and GRACEFUL_RESET fields 
+    // should be used instead of HARD.
+    HARD = 2;      [deprecated=true];
     // When handling a request to perform a HARD_reset on a BGP session, the
     // implementation's behavior is determined by the capabilities negotiated with
     // the peer. The following actions are required for each scenario:

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -52,43 +52,36 @@ message ClearBGPNeighborRequest {
     // When handling a request to perform a HARD_RESET on a BGP session, the
     // implementation's behavior is determined by the capabilities negotiated with
     // the peer. The following actions are required for each scenario:
-    
     // - If the BGP session does not support Graceful Restart (GR):
-    //  - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
+    //   - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
     //    peer. The value of any subcode sent is considered irrelevant.
-    //  - It must reset the TCP session.
-    //  - It must flush all routes learned over this session.
-    
+    //   - It must reset the TCP session.
+    //   - It must flush all routes learned over this session.
     // - If the BGP session supports GR but does not support RFC 8538:
-    //  - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
+    //   - The implementation must send a BGP Cease NOTIFICATION (code 6) to the
     //       peer. The value of any subcode sent is considered irrelevant.
-    //  - It must reset the TCP session.
-    //  - It must flush all routes learned over this session.
-    
+    //   - It must reset the TCP session.
+    //   - It must flush all routes learned over this session.
     // - If the BGP session supports both GR and RFC 8538:
-    //  - The implementation must send a BGP Cease NOTIFICATION (code 6) with the
+    //   - The implementation must send a BGP Cease NOTIFICATION (code 6) with the
     //    specific subcode for "Hard Reset" (value 9).
-    //  - It must reset the TCP session.
-    //  - It must flush all routes learned over this session.
-
+    //   - It must reset the TCP session.
+    //   - It must flush all routes learned over this session.
     HARD_RESET = 3;
     // When handling a request to perform a GRACEFUL_RESET on a BGP session, the
     // implementation's behavior is determined by the capabilities negotiated with
     // the peer. A GRACEFUL_RESET is intended to trigger a graceful session
     // teardown, allowing the forwarding plane to be preserved while the BGP
     // control plane restarts. The following actions are required for each scenario:
-    
     // - If the BGP session does not support Graceful Restart (GR):
     //  - The implementation MUST return a gRPC error with the status code
     //    `FAILED_PRECONDITION`, as a graceful reset cannot be performed.
-    
     // - If the BGP session supports GR but does not support RFC 8538:
     //   - The implementation must not send a BGP NOTIFICATION message.
     //   - It must reset the TCP session.
     //   - It must retain all routes learned over this session for a period derived
     //   from the relevant timers (e.g., restart-time, LLGR, and/or ExRR), depending
     //   on the device configuration and negotiated capabilities.
-    
     // - If the BGP session supports both GR and RFC 8538:
     //   - The implementation must send a BGP Cease NOTIFICATION (code 6) with the
     //   subcode "Other Configuration Change" (value 6).
@@ -96,7 +89,6 @@ message ClearBGPNeighborRequest {
     //   - It must retain all routes learned over this session for a period derived
     //   from the relevant timers (e.g., restart-time, LLGR, and/or ExRR), depending
     //   on the device configuration and negotiated capabilities.
-
     GRACEFUL_RESET = 4;     
   }
   Mode mode = 3;       // Which mode to use for the clear operation.

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -39,7 +39,8 @@ message ClearBGPNeighborRequest {
   enum Mode {
     SOFT = 0;         // Send route-refresh and reapply policy.
     SOFTIN = 1;       // Re-apply inbound policy on stored Adj-RIB-In.
-    HARD = 2;         // Teardown and restart TCP connection.
+    HARD = 2;         // Teardown, restart TCP connection, Send Cease notification (code 6) with subcode 9 and flush all routes.
+    GRACEFUL = 4;     // Teardown, restart TCP connection, Send Cease notification (code 6) with subcode 4 and dont flush routes.
   }
   Mode mode = 3;       // Which mode to use for the clear operation.
 }

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -39,7 +39,11 @@ message ClearBGPNeighborRequest {
   enum Mode {
     SOFT = 0;         // Send route-refresh and reapply policy.
     SOFTIN = 1;       // Re-apply inbound policy on stored Adj-RIB-In.
-    HARD = 2;         // Teardown, restart TCP connection, Send Cease notification (code 6) with subcode 9 and flush all routes.
+    HARD = 2;         // Teardown, restart TCP connection, Send Cease 
+    // notification (code 6) with subcode 4. However, if the "N" bit for 
+    // Graceful-Restart" is set, then encapsulate the original Notification
+    // message in the data portion of the Subcode 9 message as per 
+    // rfc8538#section-3.1 and also Flush the routes.
     GRACEFUL = 4;     // Teardown, restart TCP connection, Send Cease notification (code 6) with subcode 4.
   }
   Mode mode = 3;       // Which mode to use for the clear operation.

--- a/bgp/bgp.proto
+++ b/bgp/bgp.proto
@@ -74,7 +74,7 @@ message ClearBGPNeighborRequest {
     // teardown, allowing the forwarding plane to be preserved while the BGP
     // control plane restarts. The following actions are required for each scenario:
     // - If the BGP session does not support Graceful Restart (GR):
-    //  - The implementation MUST return a gRPC error with the status code
+    //   - The implementation MUST return a gRPC error with the status code
     //    `FAILED_PRECONDITION`, as a graceful reset cannot be performed.
     // - If the BGP session supports GR but does not support RFC 8538:
     //   - The implementation must not send a BGP NOTIFICATION message.


### PR DESCRIPTION
Current gNOI.BGP proto lacks guidance on how the ClearBGPNeighborRequest.Hard must be handled. As per RFC4486, code6 subcode 4,

```If a BGP speaker decides to administratively reset the peering with a neighbor, then the speaker SHOULD send a NOTIFICATION message with the Error Code Cease and the Error Subcode "Administrative Reset".``` 

which basically leaves implementations to make a choice if they should "reset TCP connection" and "Flush all routes OR not Flush all routes". Hence in rfc8538#section-3.2 for GR a new subcode 9 called `HARD RESET` was introduced to clear such ambiguities so the GR process can be handled more predictively.
Having said that, the gNOI.ClearBGPNeighborRequest API must also have 2 options for reseting a TCP connection to match the RFC. The `GRACEFUL` option introduced in this pull expects sending subcode 4 and the existing `HARD` option expects sending subcode 9 so the GR behavior can be accurately handled by expecting implementations to flush routes post reseting the TCP connection.