### PR TITLE
Add bootconfig to Activate.  This allows the caller to provide

### DIFF
--- a/bootconfig/BUILD.bazel
+++ b/bootconfig/BUILD.bazel
@@ -28,6 +28,7 @@ use_new_compilers()
 proto_library(
     name = "bootconfig_proto",
     srcs = ["bootconfig.proto"],
+    import_prefix = "github.com/openconfig/gnoi",
     deps = [
         "//types:types_proto",
         "@com_github_openconfig_bootz//proto:bootz_proto",        

--- a/os/BUILD.bazel
+++ b/os/BUILD.bazel
@@ -28,7 +28,11 @@ use_new_compilers()
 proto_library(
     name = "os_proto",
     srcs = ["os.proto"],
-    deps = ["//types:types_proto"],
+    import_prefix = "github.com/openconfig/gnoi",
+    deps = [
+        "//types:types_proto",
+        "//bootconfig:bootconfig_proto",
+    ],
 )
 
 cc_proto_library(
@@ -51,7 +55,10 @@ go_proto_library(
     ],
     importpath = "github.com/openconfig/gnoi/os",
     proto = ":os_proto",
-    deps = ["//types"],
+    deps = [
+        "//types",
+        "//bootconfig",
+    ],
 )
 
 go_library(

--- a/os/os.proto
+++ b/os/os.proto
@@ -17,7 +17,9 @@ syntax = "proto3";
 
 package gnoi.os;
 
+import "github.com/openconfig/gnoi/bootconfig/bootconfig.proto";
 import "github.com/openconfig/gnoi/types/types.proto";
+
 
 option go_package = "github.com/openconfig/gnoi/os";
 
@@ -65,7 +67,7 @@ service OS {
   // Scenario 1 - When the Target already has the OS package:
   //
   //         Client :--------------|--------------> Target
-  //              TransferRequest -->
+  //              TransferRequest --> 
   //                              <-- [Validated|InstallError]
   //
   //
@@ -331,6 +333,14 @@ message ActivateRequest {
   // the activated OS version is required. This action CAN be executing
   // the gNOI.system.Reboot() RPC.
   bool no_reboot = 3;
+
+  // Bootconfig provides the next boot configuration to load after OS upgrade.
+  // The device will take all artifacts provided and replace them just as if
+  // a gnoi.BootConfig.Set was performed on the device.
+  // The main use case is to facilitate the new OS to utilized a new
+  // configuration syntax which was not supported in previous versions.
+  gnoi.bootconfig.SetBootConfigRequest boot_config = 4;
+
 }
 
 // The ActivateResponse is sent from the Target to the Client in response to the


### PR DESCRIPTION
a new bootconfig to the device during activate.

This allows for the device to be provided a minimum configuration to gaurentee compatibility with the new OS or provide OS version specific configuration to allow the new OS to boot.