### PR TITLE
Clarify when a verify UNAVAILABLE gRPC error is expected

### DIFF
--- a/os/os.proto
+++ b/os/os.proto
@@ -146,10 +146,9 @@ service OS {
 
   // Verify checks the running OS version. During reboot, gRPC client returns
   // the gRPC status code UNAVAILABLE while the Target is unreachable or still
-  // performing install operation on the primary control card, which should be
-  // retried by the client until successful. After the Target becomes
-  // available, it should report all ready or error states normally through
-  // VerifyResponse.
+  // performing install operation, which should be retried by the client until
+  // successful. After the Target becomes available, it should report all ready
+  // or error states normally through VerifyResponse.
   //
   // On a dual Supervisor system, if the Standby Supervisor is rebooting, it
   // should be reported in the VerifyResponse via verify_standby as

--- a/os/os.proto
+++ b/os/os.proto
@@ -145,9 +145,10 @@ service OS {
   rpc Activate(ActivateRequest) returns (ActivateResponse);
 
   // Verify checks the running OS version. During reboot, gRPC client returns
-  // the gRPC status code UNAVAILABLE while the Target is unreachable, which
-  // should be retried by the client until successful. After the Target becomes
-  // reachable, it should report all ready or error states normally through
+  // the gRPC status code UNAVAILABLE while the Target is unreachable or still
+  // performing install operation on the primary control card, which should be
+  // retried by the client until successful. After the Target becomes
+  // available, it should report all ready or error states normally through
   // VerifyResponse.
   //
   // On a dual Supervisor system, if the Standby Supervisor is rebooting, it


### PR DESCRIPTION
Clarify that an UNAVAILABLE gRPC error is expected when the device is still performing install operation on the primary control card, even if the device is reachable.