### PR TITLE
Validate updated common-ci fixes staticcheck issues.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   go:
-    uses: openconfig/common-ci/.github/workflows/basic_go.yml@v0.2.0
+    uses: openconfig/common-ci/.github/workflows/basic_go.yml@ffc3d945bf1e2e820385dfcdc93ae89ce3ff433c


### PR DESCRIPTION
Validating updates to the common CI workflow fix the issue with submitting new gNOI changes.
