### PR TITLE
Ignore deprecated warnings in staticcheck configuration.

### DIFF
--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,1 @@
+checks = ["inherit", "-SA1019"]


### PR DESCRIPTION
```
* (A) staticcheck.conf
   - Skip SA1019 which provides deprecated errors, since this repo
     contains only generated code, then there's nothing we can do
     about these.
```
