### PR TITLE
Update ci-cpp-build-gnoi.yml

### DIFF
--- a/.github/workflows/ci-cpp-build-gnoi.yml
+++ b/.github/workflows/ci-cpp-build-gnoi.yml
@@ -14,25 +14,10 @@ jobs:
     env:
       BAZEL: bazelisk-linux-amd64
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    
-    - name: Mount bazel cache
-      uses: actions/cache@v4
-      with:
-        # See https://docs.bazel.build/versions/master/output_directories.html
-        path: "~/.cache/bazel"
-        # Create a new cache entry whenever Bazel files change.
-        # See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
-        key: bazel-${{ runner.os }}-build-${{ hashFiles('**/*.bzl', '**/*.bazel') }}
-        restore-keys: |
-          bazel-${{ runner.os }}-build-
-    - name: Install bazelisk
-      run: |
-        curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.8.1/$BAZEL"
-        chmod +x $BAZEL
-        sudo mv $BAZEL /usr/local/bin/bazel
-
-    - name: Build
-      run: bazel build //...
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup Bazel
+        uses: bazelbuild/setup-bazelisk@v2 
+      - name: Build
+        run: bazel build //...


### PR DESCRIPTION
This removes the cache action which can cause problems with builds