### PR TITLE
 New param auto_negotiation in otdrconfiguartion message for otdr.proto

### DIFF
--- a/otdr/otdr.proto
+++ b/otdr/otdr.proto
@@ -85,8 +85,8 @@ message OTDRConfiguration {
   // The sampling resolution in meters.
   float sampling_resolution_m = 6;
 
-  // Whether autonegotiation is enabled for the OTDR trace.
-  bool autonegotiation = 7;
+  // The flag to depict if auto negotiation is required or not.
+  bool auto_negotiation = 7;
 }
 
 // Type definition for different profiles of fiber types. These match what is

--- a/otdr/otdr.proto
+++ b/otdr/otdr.proto
@@ -84,6 +84,9 @@ message OTDRConfiguration {
 
   // The sampling resolution in meters.
   float sampling_resolution_m = 6;
+
+  // Whether autonegotiation is enabled for the OTDR trace.
+  bool autonegotiation = 7;
 }
 
 // Type definition for different profiles of fiber types. These match what is


### PR DESCRIPTION
We are introducing a new parameter autonegotiation to enhance the OTDR scan negotiation process.

The purpose of this addition is to support the “NEGOTIATED OTDR” scan, which involves a network message handshake between two adjacent nodes (node A and node B), both equipped with OTDR devices. In this setup, node A can initiate an OTDR scan only after ensuring that node B refrains from starting its own scan on the same fiber. 
This mutual negotiation ensures the integrity and correctness of the OTDR measurement.