### PR TITLE
Clarify Packet Link Qualification generator  and reflector packet forwarding

### DIFF
--- a/packet_link_qualification/index.md
+++ b/packet_link_qualification/index.md
@@ -25,9 +25,9 @@ network wide link quality.
 Upon calling Create, the interfaces on the device will be put into a forwarding
 mode which must not contain other traffic, control or data. This means the generator
 must only originate test traffic.  The reflector must send all traffic which
-is received from the generator and not originate any of its own traffic. This may
-cause the generator or reflector endpoint to become unreachable.  The service
-implementation must gracefully handle this state.
+is received from the port connected to the generator and not originate any of its
+own traffic. This may cause the generator or reflector endpoint to become
+unreachable.  The service implementation must gracefully handle this state.
 
 **Devices must return to pre-link qualification state after the link qualification has completed or errored**
 

--- a/packet_link_qualification/index.md
+++ b/packet_link_qualification/index.md
@@ -23,8 +23,10 @@ network wide link quality.
 #### Connectivity to devices during link qualification maybe interrupted
 
 Upon calling Create, the interfaces on the device will be put into a forwarding
-mode which must not contain other traffic, control or data. This may cause the
-generator or reflector endpoint to become unreachable.  The service
+mode which must not contain other traffic, control or data. This means the generator
+must only originate test traffic.  The reflector must send all traffic which
+is received from the generator and not originate any of its own traffic. This may
+cause the generator or reflector endpoint to become unreachable.  The service
 implementation must gracefully handle this state.
 
 **Devices must return to pre-link qualification state after the link qualification has completed or errored**


### PR DESCRIPTION
The packet_link_qualification specification does not directly mention which packets the reflector should send.  

Today it says:

https://github.com/openconfig/gnoi/blob/main/packet_link_qualification/index.md?plain=1#L25-L28

```
Upon calling Create, the interfaces on the device will be put into a forwarding
mode which must not contain other traffic, control or data. This may cause the
generator or reflector endpoint to become unreachable.  The service
implementation must gracefully handle this state.
```

The "Create" RPC is used on both generator and reflector.  This implies that both nodes should not send any control or data traffic, only the test traffic.  In the case that the generator does choose to send control traffic, what should the reflector do?  

To keep the specification simple and minimize any impact to changes in the specification, we wish to clarify that the reflector should send any and all traffic received from the generator.   I've also clarified that the requirement to not send control+data traffic applies to both the generator and reflector.
