### PR TITLE
Specify that `SetBootConfig` cannot specify dynamic config.

### DIFF
--- a/bootconfig/bootconfig.proto
+++ b/bootconfig/bootconfig.proto
@@ -57,9 +57,9 @@ message GetBootConfigResponse {
 message SetBootConfigRequest {
   // The BootConfig message specified in `boot_config` MUST NOT set the
   // dynamic_oc_config and dynamic_vendor_config fields. These fields
-  // are ONLY valid during bootstrapping of a network device, after the
-  // initial bootstrap, the dynamic configuration is updated through the
-  // gNMI `Set` RPC. If either dynamic_oc_config or dynamic_vendor_config
+  // are ONLY valid during the bootz triggered bootstrapping of a network device.
+  // After the bootz bootstrap, the dynamic configuration is updated through
+  // the gNMI `Set` RPC. If either dynamic_oc_config or dynamic_vendor_config
   // is specified the `SetBootConfig` RPC MUST return an error, specifying
   // `InvalidArgument` as the error code.
   bootz.BootConfig boot_config = 1;  


### PR DESCRIPTION
```
 * (M) bootconfig/bootconfig.proto
  - https://github.com/openconfig/bootz/pull/158 adds support for
    the `BootConfig` message to specify an initial dynamic config
    as either OpenConfig or vendor-proprietary config. This
    is required to allow mutable configuration to be specified at
    initial device bootstrap. It is not valid after this initial
    bootstrap, when `gNMI.Set` manipulates the dynamic config.

    This change explicitly notes that `SetBootConfig`'s payload
    MUST NOT contain these dynamic_* fields, and if they are
    specified an error should be returned.
```
