### PR TITLE
Add set_mtu to packet_link_qualification

### DIFF
--- a/packet_link_qualification/packet_link_qualification.proto
+++ b/packet_link_qualification/packet_link_qualification.proto
@@ -12,7 +12,7 @@ import "google/rpc/status.proto";
 option go_package = 
   "github.com/openconfig/gnoi/packet_link_qualification;linkqual";
 
-option (types.gnoi_version) = "1.1.0";
+option (types.gnoi_version) = "1.2.0";
 
 service LinkQualification {
   // Create will dispatch a create operation for each interface and return.
@@ -150,6 +150,10 @@ message PacketGeneratorConfiguration {
   // Size of packets to inject.
   // if unspecified, the default value is 1500 bytes.
   uint32 packet_size = 2;
+
+  // If true, the Layer 2 MTU of the underlying interface should be set to the
+  // packet size for the duration of the test.
+  bool set_mtu = 3;
 }
 
 // A packet injector implementation defines that the generator side of the link
@@ -165,6 +169,10 @@ message PacketInjectorConfiguration {
   // Size of packets to inject.
   // if unspecified, the default value is 1500 bytes.
   uint32 packet_size = 2;
+
+  // If true, the Layer 2 MTU of the underlying interface should be set to the
+  // packet size for the duration of the test.
+  bool set_mtu = 3;
 
   // Loopback mode for this qualification.
   oneof loopback_mode {
@@ -186,7 +194,9 @@ message PmdLoopbackConfiguration {
 }
 
 message AsicLoopbackConfiguration {
-  // This is where any l2/l3/l4 match criteria would be described.
+  // The L2 MTU of the interface must be set to the packet_size for the
+  // duration of the test.
+  uint32 packet_size = 2;
 }
 // GetRequest returns the status for the provided ids.
 message GetRequest {


### PR DESCRIPTION
To avoid issues where the L2 interface MTU may be smaller than the packet_size requested for a packet link qualification test, a new field is added to ensure the interface mtu is set to the packet_size.

Instead of updating the description of the current packet_size field which would be a breaking change for plaforms that do not already do this, a new field is introduced.

For the reflector (asic loopback mode), a packet_size field is also added for the same purpose.