### PR TITLE
gnoi/os: make package_size required.

### DIFF
--- a/os/os.proto
+++ b/os/os.proto
@@ -193,11 +193,10 @@ message TransferRequest {
   // if requested to install on standby only.
   bool standby_supervisor = 2;
 
-  // Optionally specify the package size in bytes of the OS package being
+  // Specify the package size in bytes of the OS package being
   // transferred.
-  // If 1) the value is different than 0
-  // and 2) the required space in the Target is larger than the available space
-  // and 3) the Target is unable to release space for the incoming OS package,
+  // If 1) the required space in the Target is larger than the available space
+  // and 2) the Target is unable to release space for the incoming OS package,
   // then the Target must reply with InstallError->Type->TOO_LARGE.
   uint64 package_size = 3;
 }


### PR DESCRIPTION
If the package_size field is unspecified, then the target will proceed without knowing how large the incoming image is.
This can lead to the target returning an error mid-RPC if it runs out of disk space to store the incoming image.

To handle this the target is left with two options. Either it must:
 1. assume some default size of the image
 2. not free-up any space for the incoming image

If the target does 1 then the assumed image size may be less than the actual image (which would cause the target to not free up enough space) OR the assumed image size may be larger than the actual image (which may cause the target to free up excess space, possibly deleting images needlessly).

If the target does 2 then the RPC will fail if there is not enough space, irrespective of if there were unused images, and someone would need to manually clean up the unused images from the target before running the RPC again.

In both cases, we could still fail the RPC if we don't have enough space.

We should therefore make this package_size field required, so that:
- the target can fail gracefully if the incoming package is too large rather than mid-way through the RPC.
- the target can free-up space properly