### PR TITLE
Specify error codes for gnoi.File

### DIFF
--- a/file/file.proto
+++ b/file/file.proto
@@ -29,7 +29,7 @@ option (types.gnoi_version) = "0.1.1";
 // (directory or file) that does not exist, the "NOT_FOUND" error must be
 // used.  For errors reading or writing a file, the most specific error
 // condition should be used.  Examples include but are not limited to
-// "PERMISSION_DENIED", "RESOURCE_EXHAUSTED or "ALREADY_EXISTS".
+// "PERMISSION_DENIED", "RESOURCE_EXHAUSTED" or "ALREADY_EXISTS".
 service File {
   // Get reads and streams the contents of a file from the target.
   // The file is streamed by sequential messages, each containing up to


### PR DESCRIPTION
It's observed that implementations vary in which error codes are used when files or directories do not exist.  This PR clarifies that the gRPC error code `NOT_FOUND` must be used for these conditions.  It also provides a suggestion for mapping file errors to gRPC errors for other common error conditions as a reminder to implementors.