### PR TITLE
Containerz: Add a field in ListPluginsResponse to indicate the plugin state

### DIFF
--- a/containerz/containerz.proto
+++ b/containerz/containerz.proto
@@ -782,6 +782,9 @@ message Plugin {
 
   // The configuration the plugin was started for.
   string config = 4;
+
+  // The state of the plugin - enabled or not.
+  bool enabled = 5;
 }
 
 message ListPluginsResponse {


### PR DESCRIPTION
As a plugin can be started or stopped, the ListPluginsResponse should indicate the state of a plugin. For this, a bool flag 'enabled' is added to indicate the current state of each plugin. This is equivalent to the 'ENABLED" column of 'docker plugin ls' command output.

This fixes issue #339 